### PR TITLE
Update SSLContext to be compatible with TLSv1.0 disablement across VMware products

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - "pip install ."
   - "pip install nose"

--- a/pyvmlib/__init__.py
+++ b/pyvmlib/__init__.py
@@ -190,7 +190,7 @@ class Connection:
             }
             if self.ignore_ssl_error:
                 # Disabling SSL certificate verification
-                context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+                context = ssl.SSLContext(ssl.PROTOCOL_TLS)
                 context.verify_mode = ssl.CERT_NONE
                 kwargs['sslContext'] = context
             try:


### PR DESCRIPTION
Update TLS protocol version from ssl.PROTOCOL_TLSv1 to ssl.PROTOCOL_TLS (which negotiates the highest TLS version that the server & client support) as TLSv1 is no longer supported from ESXi v6.0 U3 (https://kb.vmware.com/s/article/2145796).

This change _is_ backwards compatible with older versions (e.g. 6.0) of ESXi.

Also add 3.6 as a supported Python version.